### PR TITLE
fix: replace broken searchText with InternalSymbolFull filtering

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -168,13 +168,40 @@ async function main() {
 
     case "market":
       switch (sub) {
-        case "search":
-          return output(await client.get(paths.marketData("search"), {
+        case "search": {
+          const searchQuery = requireArg(rest, 0, "query");
+          const filterBy = flag(f, "filter-by") ?? "symbol";
+          const searchPage = flagNum(f, "page") ?? 1;
+          const searchPageSize = flagNum(f, "page-size") ?? 20;
+
+          if (filterBy === "symbol") {
+            return output(await client.get(paths.marketData("search"), {
+              fields: "InternalSymbolFull,SymbolFull,InstrumentDisplayName,InstrumentTypeID,ExchangeID,InstrumentID",
+              InternalSymbolFull: searchQuery.toUpperCase(),
+              pageNumber: searchPage,
+              pageSize: searchPageSize,
+            }));
+          }
+
+          // Client-side name filtering
+          const fetchSize = Math.min(searchPageSize * 5, 100);
+          const searchResult = await client.get<Record<string, unknown>>(paths.marketData("search"), {
             fields: "InternalSymbolFull,SymbolFull,InstrumentDisplayName,InstrumentTypeID,ExchangeID,InstrumentID",
-            searchText: requireArg(rest, 0, "query"),
-            pageNumber: flagNum(f, "page") ?? 1,
-            pageSize: flagNum(f, "page-size") ?? 20,
-          }));
+            pageNumber: searchPage,
+            pageSize: fetchSize,
+          });
+          const searchItems = (searchResult.items ?? searchResult.Items) as Array<Record<string, unknown>> | undefined;
+          if (!searchItems) return output(searchResult);
+
+          const lowerQuery = searchQuery.toLowerCase();
+          const filtered = searchItems.filter((item) => {
+            const displayName = String(item.InstrumentDisplayName ?? "").toLowerCase();
+            const symbolFull = String(item.SymbolFull ?? "").toLowerCase();
+            const internalSymbol = String(item.InternalSymbolFull ?? "").toLowerCase();
+            return displayName.includes(lowerQuery) || symbolFull.includes(lowerQuery) || internalSymbol.includes(lowerQuery);
+          });
+          return output({ ...searchResult, items: filtered.slice(0, searchPageSize), Items: undefined, totalItems: filtered.length, TotalItems: undefined });
+        }
         case "instrument":
           return output(await client.get(paths.marketData("instruments"), {
             instrumentIds: requireArg(rest, 0, "ids"),

--- a/src/tools/market-data.ts
+++ b/src/tools/market-data.ts
@@ -73,21 +73,52 @@ export function registerMarketDataTools(
 ): void {
   server.tool(
     "search_instruments",
-    "Search for instruments (stocks, crypto, ETFs, etc.) by text query or symbol",
+    "Search for instruments by symbol (exact match via API) or by name (client-side filter). Use symbol for tickers like 'AAPL', 'BTC'. Use name for display names like 'Apple', 'Bitcoin'.",
     {
-      query: z.string().describe("Search text (name, symbol, or ISIN)"),
+      query: z.string().describe("Search text — a ticker symbol (e.g. 'AAPL', 'BTC') or instrument name (e.g. 'Apple', 'Bitcoin')"),
+      filterBy: z.enum(["symbol", "name"]).default("symbol").describe("How to search: 'symbol' filters by InternalSymbolFull (exact, server-side), 'name' filters by InstrumentDisplayName (substring, client-side)"),
       page: z.number().int().positive().default(1).describe("Page number"),
       pageSize: z.number().int().min(1).max(100).default(20).describe("Results per page"),
     },
-    async ({ query, page, pageSize }) => {
+    async ({ query, filterBy, page, pageSize }) => {
       try {
-        const result = await client.get(paths.marketData("search"), {
+        if (filterBy === "symbol") {
+          // Server-side exact filter by symbol
+          const result = await client.get(paths.marketData("search"), {
+            fields: "InternalSymbolFull,SymbolFull,InstrumentDisplayName,InstrumentTypeID,ExchangeID,InstrumentID",
+            InternalSymbolFull: query.toUpperCase(),
+            pageNumber: page,
+            pageSize,
+          });
+          return jsonContent(result);
+        }
+
+        // Client-side name filtering: fetch a larger page and filter locally
+        const fetchSize = Math.min(pageSize * 5, 100);
+        const result = await client.get<Record<string, unknown>>(paths.marketData("search"), {
           fields: "InternalSymbolFull,SymbolFull,InstrumentDisplayName,InstrumentTypeID,ExchangeID,InstrumentID",
-          searchText: query,
           pageNumber: page,
-          pageSize,
+          pageSize: fetchSize,
         });
-        return jsonContent(result);
+
+        const items = (result.items ?? result.Items) as Array<Record<string, unknown>> | undefined;
+        if (!items) return jsonContent(result);
+
+        const lowerQuery = query.toLowerCase();
+        const filtered = items.filter((item) => {
+          const displayName = String(item.InstrumentDisplayName ?? "").toLowerCase();
+          const symbolFull = String(item.SymbolFull ?? "").toLowerCase();
+          const internalSymbol = String(item.InternalSymbolFull ?? "").toLowerCase();
+          return displayName.includes(lowerQuery) || symbolFull.includes(lowerQuery) || internalSymbol.includes(lowerQuery);
+        });
+
+        return jsonContent({
+          ...result,
+          items: filtered.slice(0, pageSize),
+          Items: undefined,
+          totalItems: filtered.length,
+          TotalItems: undefined,
+        });
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         return errorContent(`Failed to search instruments: ${message}`);

--- a/tests/integration/market-data.test.ts
+++ b/tests/integration/market-data.test.ts
@@ -5,65 +5,64 @@ const skip = skipIfNoCredentials();
 const ctx = skip ? null : createTestClient()!;
 
 describe.skipIf(skip)("Integration: Market Data", () => {
-  it("should search for instruments by text", async () => {
+  it("should search for instruments by symbol (server-side filter)", async () => {
     const result = await ctx!.client.get<Record<string, unknown>>(
       ctx!.paths.marketData("search"),
       {
-        fields: "InstrumentDisplayName,InstrumentID,SymbolFull",
-        searchText: "Apple",
+        fields: "InstrumentDisplayName,InstrumentID,SymbolFull,InternalSymbolFull",
+        InternalSymbolFull: "AAPL",
         pageSize: 5,
         pageNumber: 1,
       },
     );
 
     expect(result).toBeDefined();
-    // API returns lowercase "items" and "totalItems"
     const items = (result.items ?? result.Items) as Array<Record<string, unknown>> | undefined;
     expect(items).toBeDefined();
+    expect(items!.length).toBeGreaterThan(0);
 
-    // At least one result should contain "Apple" (case-insensitive)
+    // The result should contain Apple
     const hasApple = items!.some((item) => {
-      const displayName = String(item.InstrumentDisplayName ?? "").toLowerCase();
-      const symbolFull = String(item.SymbolFull ?? "").toLowerCase();
-      return displayName.includes("apple") || symbolFull.includes("apple");
+      const internalSymbol = String(item.InternalSymbolFull ?? "").toUpperCase();
+      return internalSymbol.includes("AAPL");
     });
     expect(hasApple).toBe(true);
   });
 
-  it("should return different results for different search queries", async () => {
+  it("should return different results for different symbol queries", async () => {
     const appleResult = await ctx!.client.get<Record<string, unknown>>(
       ctx!.paths.marketData("search"),
       {
-        fields: "InstrumentID",
-        searchText: "Apple",
+        fields: "InstrumentID,InternalSymbolFull",
+        InternalSymbolFull: "AAPL",
         pageSize: 1,
         pageNumber: 1,
       },
     );
-    const bitcoinResult = await ctx!.client.get<Record<string, unknown>>(
+    const btcResult = await ctx!.client.get<Record<string, unknown>>(
       ctx!.paths.marketData("search"),
       {
-        fields: "InstrumentID",
-        searchText: "Bitcoin",
+        fields: "InstrumentID,InternalSymbolFull",
+        InternalSymbolFull: "BTC",
         pageSize: 1,
         pageNumber: 1,
       },
     );
 
     const appleItems = (appleResult.items ?? appleResult.Items) as Array<Record<string, unknown>>;
-    const bitcoinItems = (bitcoinResult.items ?? bitcoinResult.Items) as Array<Record<string, unknown>>;
+    const btcItems = (btcResult.items ?? btcResult.Items) as Array<Record<string, unknown>>;
 
     expect(appleItems.length).toBeGreaterThan(0);
-    expect(bitcoinItems.length).toBeGreaterThan(0);
-    expect(appleItems[0].InstrumentID).not.toBe(bitcoinItems[0].InstrumentID);
+    expect(btcItems.length).toBeGreaterThan(0);
+    expect(appleItems[0].InstrumentID).not.toBe(btcItems[0].InstrumentID);
   });
 
-  it("should return empty or no results for nonsensical query", async () => {
+  it("should return empty or no results for nonsensical symbol", async () => {
     const result = await ctx!.client.get<Record<string, unknown>>(
       ctx!.paths.marketData("search"),
       {
         fields: "InstrumentID",
-        searchText: "xyzzznotaninstrument99999",
+        InternalSymbolFull: "XYZZZNOTASYMBOL99999",
         pageSize: 5,
         pageNumber: 1,
       },

--- a/tests/unit/tools/market-data.test.ts
+++ b/tests/unit/tools/market-data.test.ts
@@ -160,7 +160,7 @@ describe("enrichWithNames", () => {
 });
 
 describe("market-data tool handlers (via mock client)", () => {
-  it("search_instruments calls correct path with correct params", async () => {
+  it("search_instruments (symbol mode) sends InternalSymbolFull param", async () => {
     const paths = createPathResolver("demo");
     const mockFetch = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({ items: [], totalItems: 0 }), {
@@ -179,7 +179,7 @@ describe("market-data tool handlers (via mock client)", () => {
 
     const result = await client.get(paths.marketData("search"), {
       fields: "InternalSymbolFull,SymbolFull,InstrumentDisplayName,InstrumentTypeID,ExchangeID,InstrumentID",
-      searchText: "Apple",
+      InternalSymbolFull: "AAPL",
       pageNumber: 1,
       pageSize: 20,
     });
@@ -188,7 +188,8 @@ describe("market-data tool handlers (via mock client)", () => {
     const [url] = mockFetch.mock.calls[0] as [string, RequestInit];
     const parsed = new URL(url);
     expect(parsed.pathname).toBe("/api/v1/market-data/search");
-    expect(parsed.searchParams.get("searchText")).toBe("Apple");
+    expect(parsed.searchParams.get("InternalSymbolFull")).toBe("AAPL");
+    expect(parsed.searchParams.has("searchText")).toBe(false);
     expect(parsed.searchParams.get("pageNumber")).toBe("1");
     expect(parsed.searchParams.get("pageSize")).toBe("20");
     expect(result).toEqual({ items: [], totalItems: 0 });
@@ -212,7 +213,7 @@ describe("market-data tool handlers (via mock client)", () => {
     );
 
     await expect(
-      client.get(paths.marketData("search"), { searchText: "test" }),
+      client.get(paths.marketData("search"), { InternalSymbolFull: "TEST" }),
     ).rejects.toThrow("Bad request");
   });
 


### PR DESCRIPTION
## Summary

**Root cause**: The eToro API ignores the `searchText` query parameter entirely — every query returned all 11,168 instruments unfiltered. The API uses **field-based filtering** where any response field name can be passed as a query param to filter results.

This was confirmed by:
- Multiple independent eToro API clients (etoropy, hive-trader, syedair/mcp-servers) all using `InternalSymbolFull`
- Official eToro API docs stating "each field in the response can be utilized as a filter"

### Changes

- **Replaced `searchText` with `InternalSymbolFull`** for server-side exact symbol filtering (e.g. `AAPL`, `BTC`)
- **Added `filterBy` parameter** to `search_instruments`:
  - `symbol` (default) — server-side exact match via `InternalSymbolFull`
  - `name` — client-side substring match on `InstrumentDisplayName`, `SymbolFull`, and `InternalSymbolFull`
- **Updated CLI** with `--filter-by` flag: `etoro-cli market search "AAPL"` or `etoro-cli market search "Apple" --filter-by name`
- **Updated all tests** — unit and integration tests now use `InternalSymbolFull`
- **Zero `searchText` references remain** in source code

## Test plan

- [x] `npm run build` passes
- [x] `npm test` — 138 tests pass
- [x] No `searchText` references in `src/`
- [ ] Verify with live credentials: `etoro-cli market search "AAPL"` returns Apple (not 11,168 instruments)
- [ ] Verify: `etoro-cli market search "BTC"` returns Bitcoin
- [ ] Verify: `etoro-cli market search "Apple" --filter-by name` returns Apple via client-side filter