### PR TITLE
fix: search filtering, API response shapes, TotalEquity calculation

### DIFF
--- a/src/tools/portfolio.ts
+++ b/src/tools/portfolio.ts
@@ -15,7 +15,7 @@ export function flattenPnl(result: unknown): unknown {
   if (!portfolio) return result;
 
   return {
-    TotalEquity: portfolio.credit ?? portfolio.Credit ?? portfolio.totalEquity ?? portfolio.TotalEquity,
+    TotalEquity: (Number(portfolio.credit ?? portfolio.Credit ?? 0)) + (Number(portfolio.unrealizedPnL ?? portfolio.UnrealizedPnL ?? 0)),
     TotalPnL: portfolio.unrealizedPnL ?? portfolio.UnrealizedPnL ?? portfolio.totalPnL ?? portfolio.TotalPnL,
     UnrealizedPnL: portfolio.unrealizedPnL ?? portfolio.UnrealizedPnL,
     Cash: portfolio.credit ?? portfolio.Credit,

--- a/tests/unit/tools/portfolio.test.ts
+++ b/tests/unit/tools/portfolio.test.ts
@@ -11,7 +11,8 @@ describe("flattenPnl", () => {
       },
     };
     const result = flattenPnl(nested) as Record<string, unknown>;
-    expect(result.TotalEquity).toBe(10000);
+    // TotalEquity = credit + unrealizedPnL = 10000 + 500
+    expect(result.TotalEquity).toBe(10500);
     expect(result.TotalPnL).toBe(500);
     expect(result.UnrealizedPnL).toBe(500);
     expect(result.Cash).toBe(10000);
@@ -27,9 +28,24 @@ describe("flattenPnl", () => {
       },
     };
     const result = flattenPnl(nested) as Record<string, unknown>;
-    expect(result.TotalEquity).toBe(8000);
+    // TotalEquity = Credit + UnrealizedPnL = 8000 + (-200)
+    expect(result.TotalEquity).toBe(7800);
     expect(result.TotalPnL).toBe(-200);
     expect(result.Cash).toBe(8000);
+  });
+
+  it("should compute TotalEquity correctly with negative unrealizedPnL (bug regression)", () => {
+    const nested = {
+      clientPortfolio: {
+        credit: 71103.83,
+        unrealizedPnL: -769.85,
+      },
+    };
+    const result = flattenPnl(nested) as Record<string, unknown>;
+    // The reported bug: TotalEquity was set to credit (71103.83) instead of credit + unrealizedPnL
+    expect(result.TotalEquity).toBeCloseTo(70333.98, 2);
+    expect(result.Cash).toBe(71103.83);
+    expect(result.UnrealizedPnL).toBe(-769.85);
   });
 
   it("should return raw result when no clientPortfolio key exists", () => {


### PR DESCRIPTION
## Summary

Fixes three categories of bugs discovered during integration testing against the live eToro API:

### Search filtering was completely broken
- The eToro API **ignores `searchText`** — every query returned all 11,168 instruments unfiltered
- Replaced with `InternalSymbolFull` for server-side exact symbol matching (e.g. `AAPL`, `BTC`)
- Added `filterBy` parameter: `symbol` (default, server-side) or `name` (client-side substring match)
- Updated CLI with `--filter-by` flag

### API response shapes were wrong in tests and enrichment
- API returns wrapped objects (`{ rates: [...] }`, `{ instrumentDisplayDatas: [...] }`) not bare arrays
- All field names are **camelCase** (`instrumentID`, `instrumentDisplayName`) not PascalCase
- Fixed `enrichWithNames` to unwrap/re-wrap response wrappers and support camelCase
- Rewrote all integration tests to assert actual API response shapes

### TotalEquity calculation bug
- `flattenPnl` was setting `TotalEquity = credit` (just Cash), ignoring `unrealizedPnL`
- Fixed to `TotalEquity = credit + unrealizedPnL`
- Added regression test with exact values from bug report

### Documentation
- Updated SKILL.md and README.md with `filterBy`/`--filter-by` docs
- Updated `includeNames` param on `get_rates`
- Fixed all jq examples from PascalCase to camelCase

## Test plan

- [x] `npm run build` passes
- [x] Unit tests: 152 pass (11 files)
- [x] Integration tests: 23 pass (7 files) — all hitting live eToro API
- [x] Search for `AAPL` returns Apple (not 11,168 instruments)
- [x] Different symbols return different results
- [x] Nonsensical symbol returns empty results
- [x] TotalEquity = credit + unrealizedPnL (regression test with exact bug report values)