### PR TITLE
feat: error normalization, rate limit visibility, table output

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,6 +6,7 @@ import { createPathResolver } from "./utils/path-resolver.js";
 import { EtoroApiError } from "./types/errors.js";
 import { flattenCandles } from "./tools/market-data.js";
 import { flattenPnl } from "./tools/portfolio.js";
+import { formatTable } from "./utils/table-formatter.js";
 
 // --- Arg parsing ---
 
@@ -63,7 +64,16 @@ function requireArg(args: string[], index: number, name: string): string {
 
 // --- Output ---
 
+let outputFormat: "json" | "table" = "json";
+
 function output(data: unknown): void {
+  if (outputFormat === "table") {
+    const table = formatTable(data);
+    if (table) {
+      console.log(table);
+      return;
+    }
+  }
   console.log(JSON.stringify(data, null, 2));
 }
 
@@ -80,6 +90,8 @@ Global options:
   --api-key <key>          eToro API key (or ETORO_API_KEY env var)
   --user-key <key>         eToro user key (or ETORO_USER_KEY env var)
   --environment <env>      demo or real (default: demo)
+  --verbose                Show rate limit status on each request
+  --output <format>        Output format: json (default) or table
 
 Commands:
   identity                           Get authenticated user info
@@ -146,6 +158,8 @@ Commands:
   discovery recommendations          Personalized recommendations
     --count <n>                        Number of items (default: 10)
 
+  rate-limit                         Show current rate limit status
+
   help                               Show this help message
 `;
 
@@ -161,7 +175,10 @@ async function main() {
   }
 
   const config = loadConfig();
-  const client = new EtoroClient(config);
+  const verbose = f["verbose"] === "true";
+  const fmt = flag(f, "output");
+  if (fmt === "table") outputFormat = "table";
+  const client = new EtoroClient(config, { verbose });
   const paths = createPathResolver(config.environment);
 
   switch (command) {
@@ -410,6 +427,14 @@ async function main() {
           error(`Unknown discovery subcommand: ${sub}. Try: curated, recommendations`);
       }
       break;
+
+    case "rate-limit": {
+      const status = client.getRateLimitStatus();
+      return output({
+        GET: { remaining: status.GET.remaining, limit: status.GET.limit, resetInSeconds: Math.ceil(status.GET.resetInMs / 1000) },
+        WRITE: { remaining: status.WRITE.remaining, limit: status.WRITE.limit, resetInSeconds: Math.ceil(status.WRITE.resetInMs / 1000) },
+      });
+    }
 
     default:
       error(`Unknown command: ${command}. Run 'etoro-cli help' for usage.`);

--- a/src/client.ts
+++ b/src/client.ts
@@ -11,17 +11,25 @@ export class EtoroClient {
   private readonly config: EtoroConfig;
   private readonly rateLimiter: RateLimiter;
   private readonly fetchFn: typeof fetch;
+  private readonly verbose: boolean;
 
   constructor(
     config: EtoroConfig,
     options?: {
       rateLimiter?: RateLimiter;
       fetchFn?: typeof fetch;
+      verbose?: boolean;
     },
   ) {
     this.config = config;
     this.rateLimiter = options?.rateLimiter ?? new RateLimiter();
     this.fetchFn = options?.fetchFn ?? globalThis.fetch;
+    this.verbose = options?.verbose ?? false;
+  }
+
+  /** Get current rate limit status for all buckets. */
+  getRateLimitStatus() {
+    return this.rateLimiter.getAllStatus();
   }
 
   private buildHeaders(): Record<string, string> {
@@ -44,6 +52,11 @@ export class EtoroClient {
   ): Promise<T> {
     const rateLimitType = method === "GET" ? "GET" : "WRITE";
     await this.rateLimiter.acquire(rateLimitType);
+
+    if (this.verbose) {
+      const status = this.rateLimiter.getStatus(rateLimitType);
+      process.stderr.write(`[rate-limit] ${rateLimitType} ${status.remaining}/${status.limit} remaining\n`);
+    }
 
     const url = new URL(path, BASE_URL);
     if (options?.params) {
@@ -82,25 +95,44 @@ export class EtoroClient {
         }
 
         if (!response.ok) {
+          const retryAfter = response.headers.get("Retry-After");
+          const contentType = response.headers.get("Content-Type") ?? "";
           const body = await response.text();
+
           let parsed: unknown;
-          try {
-            parsed = JSON.parse(body);
-          } catch {
-            parsed = body;
-          }
-          const errorCode =
-            typeof parsed === "object" &&
-            parsed !== null &&
-            "errorCode" in parsed
-              ? String((parsed as Record<string, unknown>).errorCode)
-              : undefined;
-          const message =
-            typeof parsed === "object" &&
-            parsed !== null &&
-            "message" in parsed
-              ? String((parsed as Record<string, unknown>).message)
+          let errorCode: string | undefined;
+          let message: string;
+
+          if (contentType.includes("text/html") || (typeof body === "string" && body.trimStart().startsWith("<"))) {
+            // Cloudflare or HTML error page — normalize to clean JSON
+            message = response.status === 429
+              ? `Rate limited (HTTP 429). ${retryAfter ? `Retry after ${retryAfter}s.` : "Try again later."}`
               : `HTTP ${response.status}: ${response.statusText}`;
+            parsed = {
+              error: message,
+              statusCode: response.status,
+              ...(retryAfter ? { retryAfter: parseInt(retryAfter, 10) } : {}),
+            };
+          } else {
+            try {
+              parsed = JSON.parse(body);
+            } catch {
+              parsed = body;
+            }
+            errorCode =
+              typeof parsed === "object" &&
+              parsed !== null &&
+              "errorCode" in parsed
+                ? String((parsed as Record<string, unknown>).errorCode)
+                : undefined;
+            message =
+              typeof parsed === "object" &&
+              parsed !== null &&
+              "message" in parsed
+                ? String((parsed as Record<string, unknown>).message)
+                : `HTTP ${response.status}: ${response.statusText}`;
+          }
+
           throw new EtoroApiError(message, response.status, parsed, errorCode);
         }
 

--- a/src/utils/rate-limiter.ts
+++ b/src/utils/rate-limiter.ts
@@ -58,6 +58,25 @@ export class RateLimiter {
     this.timestamps.WRITE = [];
   }
 
+  /** Get remaining requests and next reset time for a bucket. */
+  getStatus(type: BucketType): { remaining: number; limit: number; resetInMs: number } {
+    const now = Date.now();
+    this.pruneExpired(type, now);
+    const bucket = this.timestamps[type];
+    const limit = this.limits[type];
+    const remaining = Math.max(0, limit - bucket.length);
+    const resetInMs = bucket.length > 0 ? (bucket[0]! + this.windowMs - now) : 0;
+    return { remaining, limit, resetInMs: Math.max(0, resetInMs) };
+  }
+
+  /** Get status for all buckets. */
+  getAllStatus(): Record<BucketType, { remaining: number; limit: number; resetInMs: number }> {
+    return {
+      GET: this.getStatus("GET"),
+      WRITE: this.getStatus("WRITE"),
+    };
+  }
+
   private pruneExpired(type: BucketType, now: number): void {
     const bucket = this.timestamps[type];
     const cutoff = now - this.windowMs;

--- a/src/utils/table-formatter.ts
+++ b/src/utils/table-formatter.ts
@@ -1,0 +1,45 @@
+/** Simple ASCII table formatter for CLI output. No external dependencies. */
+
+export function formatTable(data: unknown): string | null {
+  // Only format arrays of objects
+  if (!Array.isArray(data) || data.length === 0) return null;
+  if (typeof data[0] !== "object" || data[0] === null) return null;
+
+  const rows = data as Array<Record<string, unknown>>;
+  const columns = Object.keys(rows[0]);
+
+  // Skip deeply nested objects — not suitable for tables
+  if (columns.length > 15) return null;
+
+  // Calculate column widths
+  const widths = new Map<string, number>();
+  for (const col of columns) {
+    widths.set(col, col.length);
+  }
+  for (const row of rows) {
+    for (const col of columns) {
+      const val = formatCell(row[col]);
+      const current = widths.get(col) ?? 0;
+      if (val.length > current) {
+        widths.set(col, Math.min(val.length, 40)); // cap at 40 chars
+      }
+    }
+  }
+
+  // Build header
+  const header = columns.map((c) => c.padEnd(widths.get(c)!)).join("  ");
+  const separator = columns.map((c) => "─".repeat(widths.get(c)!)).join("──");
+
+  // Build rows
+  const lines = rows.map((row) =>
+    columns.map((c) => formatCell(row[c]).padEnd(widths.get(c)!)).join("  "),
+  );
+
+  return [header, separator, ...lines].join("\n");
+}
+
+function formatCell(value: unknown): string {
+  if (value === null || value === undefined) return "—";
+  if (typeof value === "object") return JSON.stringify(value);
+  return String(value).slice(0, 40);
+}

--- a/tests/unit/client.test.ts
+++ b/tests/unit/client.test.ts
@@ -261,6 +261,62 @@ describe("EtoroClient", () => {
       }
     });
 
+    it("normalizes HTML error responses (e.g. Cloudflare) to clean JSON", async () => {
+      vi.useFakeTimers();
+      const htmlBody = "<html><body><h1>429 Too Many Requests</h1></body></html>";
+      // Return 429 HTML for all attempts so retries exhaust
+      mockFetch.mockImplementation(() =>
+        Promise.resolve(new Response(htmlBody, {
+          status: 429,
+          statusText: "Too Many Requests",
+          headers: { "Content-Type": "text/html", "Retry-After": "30" },
+        })),
+      );
+
+      const promise = client.get("/api/v1/test");
+      const assertion = expect(promise).rejects.toThrow(EtoroApiError);
+      await vi.runAllTimersAsync();
+
+      try {
+        await promise;
+      } catch (error) {
+        const apiError = error as EtoroApiError;
+        expect(apiError.statusCode).toBe(429);
+        expect(apiError.message).toContain("Rate limited");
+        expect(apiError.message).toContain("30s");
+        const body = apiError.body as Record<string, unknown>;
+        expect(body.statusCode).toBe(429);
+        expect(body.retryAfter).toBe(30);
+      }
+
+      await assertion;
+      vi.useRealTimers();
+    });
+
+    it("normalizes HTML 500 errors without Content-Type header", async () => {
+      const htmlBody = "<!DOCTYPE html><html><body>Server Error</body></html>";
+      mockFetch.mockResolvedValueOnce(
+        new Response(htmlBody, {
+          status: 500,
+          statusText: "Internal Server Error",
+          headers: {},
+        }),
+      );
+
+      try {
+        await client.get("/api/v1/test");
+        expect.unreachable("Should have thrown");
+      } catch (error) {
+        const apiError = error as EtoroApiError;
+        expect(apiError).toBeInstanceOf(EtoroApiError);
+        expect(apiError.statusCode).toBe(500);
+        expect(apiError.message).toBe("HTTP 500: Internal Server Error");
+        // Body should be clean JSON, not raw HTML
+        const body = apiError.body as Record<string, unknown>;
+        expect(body.statusCode).toBe(500);
+      }
+    });
+
     it("does NOT retry non-429 errors", async () => {
       const errorBody = { message: "Bad request" };
       mockFetch.mockResolvedValueOnce(jsonResponse(errorBody, 400));

--- a/tests/unit/utils/rate-limiter.test.ts
+++ b/tests/unit/utils/rate-limiter.test.ts
@@ -157,4 +157,42 @@ describe("RateLimiter", () => {
     await promise;
     expect(resolved).toBe(true);
   });
+
+  describe("getStatus", () => {
+    it("returns full remaining when no requests made", () => {
+      const limiter = new RateLimiter({ getLimit: 60, writeLimit: 20 });
+      const status = limiter.getStatus("GET");
+      expect(status.remaining).toBe(60);
+      expect(status.limit).toBe(60);
+      expect(status.resetInMs).toBe(0);
+    });
+
+    it("decrements remaining after acquire", async () => {
+      const limiter = new RateLimiter({ getLimit: 60, writeLimit: 20 });
+      await limiter.acquire("GET");
+      const status = limiter.getStatus("GET");
+      expect(status.remaining).toBe(59);
+      expect(status.limit).toBe(60);
+      expect(status.resetInMs).toBeGreaterThan(0);
+    });
+
+    it("tracks GET and WRITE independently via getAllStatus", async () => {
+      const limiter = new RateLimiter({ getLimit: 60, writeLimit: 20 });
+      await limiter.acquire("GET");
+      await limiter.acquire("GET");
+      await limiter.acquire("WRITE");
+
+      const allStatus = limiter.getAllStatus();
+      expect(allStatus.GET.remaining).toBe(58);
+      expect(allStatus.WRITE.remaining).toBe(19);
+    });
+
+    it("resets remaining after reset()", async () => {
+      const limiter = new RateLimiter({ getLimit: 60, writeLimit: 20 });
+      await limiter.acquire("GET");
+      limiter.reset();
+      const status = limiter.getStatus("GET");
+      expect(status.remaining).toBe(60);
+    });
+  });
 });

--- a/tests/unit/utils/table-formatter.test.ts
+++ b/tests/unit/utils/table-formatter.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { formatTable } from "../../../src/utils/table-formatter.js";
+
+describe("formatTable", () => {
+  it("should format an array of objects as an ASCII table", () => {
+    const data = [
+      { Name: "Apple", Symbol: "AAPL", Price: 150.5 },
+      { Name: "Microsoft", Symbol: "MSFT", Price: 300.0 },
+    ];
+    const result = formatTable(data);
+    expect(result).toContain("Name");
+    expect(result).toContain("Symbol");
+    expect(result).toContain("Price");
+    expect(result).toContain("Apple");
+    expect(result).toContain("AAPL");
+    expect(result).toContain("150.5");
+    expect(result).toContain("Microsoft");
+  });
+
+  it("should return null for empty arrays", () => {
+    expect(formatTable([])).toBeNull();
+  });
+
+  it("should return null for non-array input", () => {
+    expect(formatTable({ key: "value" })).toBeNull();
+    expect(formatTable("string")).toBeNull();
+    expect(formatTable(null)).toBeNull();
+  });
+
+  it("should return null for arrays of primitives", () => {
+    expect(formatTable([1, 2, 3])).toBeNull();
+  });
+
+  it("should handle null/undefined cell values with dash", () => {
+    const data = [
+      { Name: "Test", Value: null },
+    ];
+    const result = formatTable(data);
+    expect(result).toContain("—");
+  });
+
+  it("should truncate long values at 40 chars", () => {
+    const data = [
+      { Name: "A".repeat(60) },
+    ];
+    const result = formatTable(data);
+    expect(result).toBeDefined();
+    // The cell value should be truncated
+    const lines = result!.split("\n");
+    const dataLine = lines[2]; // header, separator, first data line
+    expect(dataLine!.length).toBeLessThan(65);
+  });
+});


### PR DESCRIPTION
## Summary
Three improvements from the bug report, all opt-in:

- **IMP-4 (Error normalization)**: HTML error responses from Cloudflare/429s are now returned as clean JSON `{error, statusCode, retryAfter}` instead of raw HTML in the body field. Detects HTML by Content-Type header or leading `<` in body.

- **IMP-3 (Rate limit visibility)**: 
  - `RateLimiter.getStatus(type)` / `getAllStatus()` — inspect remaining requests and reset time
  - `EtoroClient.getRateLimitStatus()` — public accessor
  - `--verbose` CLI flag — prints `[rate-limit] GET 58/60 remaining` to stderr on each request
  - `etoro-cli rate-limit` command — shows current bucket status

- **IMP-5 (Table output)**:
  - `--output table` CLI flag — renders arrays of objects as ASCII tables
  - Zero dependencies — custom formatter, no external libraries
  - Falls back to JSON for non-tabular data
  - Default remains JSON (opt-in)

## Test plan
- [x] 164 tests pass (152 existing + 12 new)
- [x] HTML error normalization tests (429 with Retry-After, 500 without Content-Type)
- [x] Rate limiter getStatus/getAllStatus tests (4 tests)
- [x] Table formatter tests (6 tests: arrays, empty, primitives, null values, truncation)
- [x] Build passes with no type errors
- [ ] Manual: `etoro-cli market search "AAPL" --output table`
- [ ] Manual: `etoro-cli rate-limit`
- [ ] Manual: `etoro-cli market rates 1 --verbose`