### PR TITLE
fix: trade close auto-lookup fails to unwrap clientPortfolio

### DIFF
--- a/src/tools/trading.ts
+++ b/src/tools/trading.ts
@@ -9,13 +9,17 @@ export function lookupInstrumentId(portfolio: unknown, positionId: number): numb
   if (typeof portfolio !== "object" || portfolio === null) return undefined;
   const obj = portfolio as Record<string, unknown>;
 
+  // API returns { clientPortfolio: { positions: [...] } } — unwrap if needed
+  const clientPortfolio = (obj.clientPortfolio ?? obj.ClientPortfolio) as Record<string, unknown> | undefined;
+  const source = clientPortfolio ?? obj;
+
   let positions: unknown[];
   if (Array.isArray(portfolio)) {
     positions = portfolio;
-  } else if (Array.isArray(obj.positions)) {
-    positions = obj.positions;
-  } else if (Array.isArray(obj.Positions)) {
-    positions = obj.Positions;
+  } else if (Array.isArray((source as Record<string, unknown>).positions)) {
+    positions = (source as Record<string, unknown>).positions as unknown[];
+  } else if (Array.isArray((source as Record<string, unknown>).Positions)) {
+    positions = (source as Record<string, unknown>).Positions as unknown[];
   } else {
     return undefined;
   }

--- a/tests/unit/tools/trading.test.ts
+++ b/tests/unit/tools/trading.test.ts
@@ -38,6 +38,34 @@ describe("lookupInstrumentId", () => {
     expect(lookupInstrumentId(portfolio, 999)).toBeUndefined();
   });
 
+  it("finds instrumentID from actual API shape { clientPortfolio: { positions: [...] } }", () => {
+    const portfolio = {
+      clientPortfolio: {
+        positions: [
+          { positionID: 3471852411, instrumentID: 18 },
+          { positionID: 3471853059, instrumentID: 1001 },
+          { positionID: 3471853067, instrumentID: 100000 },
+        ],
+        credit: 71103.83,
+        unrealizedPnL: -769.85,
+      },
+    };
+    expect(lookupInstrumentId(portfolio, 3471852411)).toBe(18);
+    expect(lookupInstrumentId(portfolio, 3471853059)).toBe(1001);
+    expect(lookupInstrumentId(portfolio, 3471853067)).toBe(100000);
+  });
+
+  it("finds InstrumentID from PascalCase { ClientPortfolio: { Positions: [...] } }", () => {
+    const portfolio = {
+      ClientPortfolio: {
+        Positions: [
+          { PositionID: 123, InstrumentID: 18 },
+        ],
+      },
+    };
+    expect(lookupInstrumentId(portfolio, 123)).toBe(18);
+  });
+
   it("returns undefined for null/undefined/non-object input", () => {
     expect(lookupInstrumentId(null, 123)).toBeUndefined();
     expect(lookupInstrumentId(undefined, 123)).toBeUndefined();


### PR DESCRIPTION
## Summary

`etoro-cli trade close <positionId>` failed with "Could not find position in portfolio" even when the position exists.

**Root cause:** `lookupInstrumentId()` checked for `obj.positions` but the portfolio API returns `{ clientPortfolio: { positions: [...] } }`. It never unwrapped `clientPortfolio`.

**Fix:** Unwrap `clientPortfolio`/`ClientPortfolio` before searching for positions.

**Tests:** Added regression tests with actual API response shape (`{ clientPortfolio: { positions: [...] } }`). 181 tests pass.

## Test plan

- [x] `npm run build` passes
- [x] `npm test` — 181 pass
- [ ] Manual: `etoro-cli trade close <positionId>` without `--instrument` flag

Closes #23