### PR TITLE
fix: trade cancel now handles limit orders

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -130,7 +130,8 @@ Commands:
     --leverage <n>                     Leverage (required)
     --amount <n>                       Cash amount (required)
     --rate <n>                         Limit price (required)
-  trade cancel <orderId>             Cancel an open or limit order
+  trade cancel <orderId>             Cancel an open or limit order (auto-detects type)
+    --type <type>                      limit or market (optional, auto-detects if omitted)
 
   social search                      Search/discover traders
     --period <period>                  Required: CurrMonth|CurrYear|LastYear|etc.
@@ -346,10 +347,27 @@ async function main() {
           if (flag(f, "take-profit")) body.TakeProfitRate = Number(flag(f, "take-profit"));
           return output(await client.post(paths.trading("limit-orders"), body));
         }
-        case "cancel":
-          return output(await client.delete(
-            paths.trading(`market-open-orders/${requireArg(rest, 0, "orderId")}`),
-          ));
+        case "cancel": {
+          const cancelOrderId = requireArg(rest, 0, "orderId");
+          const cancelType = flag(f, "type");
+          if (cancelType === "market") {
+            return output(await client.delete(paths.trading(`market-open-orders/${cancelOrderId}`)));
+          }
+          if (cancelType === "limit") {
+            return output(await client.delete(paths.trading(`limit-orders/${cancelOrderId}`)));
+          }
+          // Auto-detect: try limit-orders first (most common cancel case), fall back to market-open-orders
+          try {
+            return output(await client.delete(paths.trading(`limit-orders/${cancelOrderId}`)));
+          } catch (limitErr) {
+            try {
+              return output(await client.delete(paths.trading(`market-open-orders/${cancelOrderId}`)));
+            } catch {
+              // Re-throw the original limit error if both fail
+              throw limitErr;
+            }
+          }
+        }
         default:
           error(`Unknown trade subcommand: ${sub}. Try: open, open-units, close, limit, cancel`);
       }


### PR DESCRIPTION
## Summary
`trade cancel` was only calling `DELETE market-open-orders/{id}`, which silently returned a token but didn't actually cancel limit orders. Limit orders need `DELETE limit-orders/{id}`.

Fix: `trade cancel` now auto-detects — tries `limit-orders` first (most common cancel case), falls back to `market-open-orders`. Also accepts `--type limit|market` to skip detection.

The MCP tool already had separate `cancel_limit_order` and `cancel_open_order` actions — this was a CLI-only bug.

## Test plan
- [x] 181 tests pass, build clean
- [ ] Manual: `etoro-cli trade cancel 338055432` cancels the NVDA limit order
- [ ] Manual: `etoro-cli trade cancel 338048894` cancels the GOOG limit order
- [ ] Manual: `etoro-cli trade cancel 338048897` cancels the MSFT limit order
- [ ] Verify orders disappear from `etoro-cli portfolio pnl | jq '.orders'`