### PR TITLE
fix: search --filter-by name uses server-side internalInstrumentDisplayName

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -194,53 +194,27 @@ async function main() {
           const filterBy = flag(f, "filter-by") ?? "symbol";
           const searchPage = flagNum(f, "page") ?? 1;
           const searchPageSize = flagNum(f, "page-size") ?? 20;
-          const searchFields = "InternalSymbolFull,SymbolFull,InstrumentDisplayName,InstrumentTypeID,ExchangeID,InstrumentID";
 
           if (filterBy === "symbol") {
-            // Try server-side exact symbol match first
+            // Server-side exact symbol match
             const symbolResult = await client.get<Record<string, unknown>>(paths.marketData("search"), {
-              fields: searchFields,
               InternalSymbolFull: searchQuery.toUpperCase(),
               pageNumber: searchPage,
               pageSize: searchPageSize,
             });
-            const symbolItems = (symbolResult.items ?? symbolResult.Items) as Array<Record<string, unknown>> | undefined;
+            const symbolItems = symbolResult.items as Array<Record<string, unknown>> | undefined;
             if (symbolItems && symbolItems.length > 0) {
               return output(symbolResult);
             }
             // Fall back to name search if symbol returned nothing
           }
 
-          // Client-side name filtering: fetch up to 3 pages of 100 items
-          const lowerQuery = searchQuery.toLowerCase();
-          const allFiltered: Array<Record<string, unknown>> = [];
-          const maxPages = 3;
-          let lastResult: Record<string, unknown> | undefined;
-
-          for (let p = 1; p <= maxPages; p++) {
-            const pageResult = await client.get<Record<string, unknown>>(paths.marketData("search"), {
-              fields: searchFields,
-              pageNumber: p,
-              pageSize: 100,
-            });
-            lastResult = pageResult;
-
-            const pageItems = (pageResult.items ?? pageResult.Items) as Array<Record<string, unknown>> | undefined;
-            if (!pageItems || pageItems.length === 0) break;
-
-            const filtered = pageItems.filter((item) => {
-              const displayName = String(item.InstrumentDisplayName ?? "").toLowerCase();
-              const symbolFull = String(item.SymbolFull ?? "").toLowerCase();
-              const internalSymbol = String(item.InternalSymbolFull ?? "").toLowerCase();
-              return displayName.includes(lowerQuery) || symbolFull.includes(lowerQuery) || internalSymbol.includes(lowerQuery);
-            });
-            allFiltered.push(...filtered);
-
-            if (allFiltered.length >= searchPageSize || pageItems.length < 100) break;
-          }
-
-          if (!lastResult) return output({ items: [], totalItems: 0 });
-          return output({ ...lastResult, items: allFiltered.slice(0, searchPageSize), Items: undefined, totalItems: allFiltered.length, TotalItems: undefined });
+          // Server-side name filter via internalInstrumentDisplayName
+          return output(await client.get(paths.marketData("search"), {
+            internalInstrumentDisplayName: searchQuery,
+            pageNumber: searchPage,
+            pageSize: searchPageSize,
+          }));
         }
         case "instrument":
           return output(await client.get(paths.marketData("instruments"), {

--- a/src/tools/market-data.ts
+++ b/src/tools/market-data.ts
@@ -114,28 +114,25 @@ export function registerMarketDataTools(
 ): void {
   server.tool(
     "search_instruments",
-    "Search for instruments by symbol (exact match via API) or by name (client-side filter). Use symbol for tickers like 'AAPL', 'BTC'. Use name for display names like 'Apple', 'Bitcoin'.",
+    "Search for instruments by symbol or name. Both are server-side filters. Use symbol for tickers like 'AAPL', 'BTC'. Use name for display names like 'Apple', 'Bitcoin'.",
     {
       query: z.string().describe("Search text — a ticker symbol (e.g. 'AAPL', 'BTC') or instrument name (e.g. 'Apple', 'Bitcoin')"),
-      filterBy: z.enum(["symbol", "name"]).default("symbol").describe("How to search: 'symbol' filters by InternalSymbolFull (exact, server-side), 'name' filters by InstrumentDisplayName (substring, client-side)"),
+      filterBy: z.enum(["symbol", "name"]).default("symbol").describe("How to search: 'symbol' filters by InternalSymbolFull (exact), 'name' filters by internalInstrumentDisplayName (exact)"),
       page: z.number().int().positive().default(1).describe("Page number"),
       pageSize: z.number().int().min(1).max(100).default(20).describe("Results per page"),
     },
     async ({ query, filterBy, page, pageSize }) => {
       try {
-        const searchFields = "InternalSymbolFull,SymbolFull,InstrumentDisplayName,InstrumentTypeID,ExchangeID,InstrumentID";
-
         if (filterBy === "symbol") {
-          // Try server-side exact symbol match first
+          // Server-side exact symbol match
           const result = await client.get<Record<string, unknown>>(paths.marketData("search"), {
-            fields: searchFields,
             InternalSymbolFull: query.toUpperCase(),
             pageNumber: page,
             pageSize,
           });
 
           // If symbol search found results, return them
-          const symbolItems = (result.items ?? result.Items) as Array<Record<string, unknown>> | undefined;
+          const symbolItems = result.items as Array<Record<string, unknown>> | undefined;
           if (symbolItems && symbolItems.length > 0) {
             return jsonContent(result);
           }
@@ -143,44 +140,13 @@ export function registerMarketDataTools(
           // Fall back to name search if symbol returned nothing
         }
 
-        // Client-side name filtering: fetch up to 3 pages of 100 items and filter locally
-        const lowerQuery = query.toLowerCase();
-        const allFiltered: Array<Record<string, unknown>> = [];
-        const maxPages = 3;
-        let lastResult: Record<string, unknown> | undefined;
-
-        for (let p = 1; p <= maxPages; p++) {
-          const result = await client.get<Record<string, unknown>>(paths.marketData("search"), {
-            fields: searchFields,
-            pageNumber: p,
-            pageSize: 100,
-          });
-          lastResult = result;
-
-          const items = (result.items ?? result.Items) as Array<Record<string, unknown>> | undefined;
-          if (!items || items.length === 0) break;
-
-          const filtered = items.filter((item) => {
-            const displayName = String(item.InstrumentDisplayName ?? "").toLowerCase();
-            const symbolFull = String(item.SymbolFull ?? "").toLowerCase();
-            const internalSymbol = String(item.InternalSymbolFull ?? "").toLowerCase();
-            return displayName.includes(lowerQuery) || symbolFull.includes(lowerQuery) || internalSymbol.includes(lowerQuery);
-          });
-          allFiltered.push(...filtered);
-
-          // Stop early if we have enough results or the page was not full
-          if (allFiltered.length >= pageSize || items.length < 100) break;
-        }
-
-        if (!lastResult) return jsonContent({ items: [], totalItems: 0 });
-
-        return jsonContent({
-          ...lastResult,
-          items: allFiltered.slice(0, pageSize),
-          Items: undefined,
-          totalItems: allFiltered.length,
-          TotalItems: undefined,
+        // Server-side name filter via internalInstrumentDisplayName
+        const result = await client.get<Record<string, unknown>>(paths.marketData("search"), {
+          internalInstrumentDisplayName: query,
+          pageNumber: page,
+          pageSize,
         });
+        return jsonContent(result);
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         return errorContent(`Failed to search instruments: ${message}`);


### PR DESCRIPTION
## Summary

`etoro-cli market search "Tesla" --filter-by name` returned 0 results because the client-side name filtering was looking for `instrumentDisplayName` fields that the API doesn't return in unfiltered search results.

**Root cause:** The search API returns items with only `instrumentId` when no field-based filter is applied. The `fields` param doesn't control which fields come back. Client-side filtering had nothing to match on.

**Fix:** Replaced client-side filtering with server-side `internalInstrumentDisplayName` query parameter (same pattern as `InternalSymbolFull` for symbols). Now returns full results directly from the API.

**Verified live:**
- `internalInstrumentDisplayName: "Tesla"` returns 7 results including Tesla Motors (TSLA)
- `internalInstrumentDisplayName: "Apple"` returns 4 results including Apple (AAPL)
- Symbol fallback still works: searching "Tesla" as symbol returns 0, falls back to name search automatically

## Test plan

- [x] `npm run build` passes
- [x] Unit tests: 181 pass
- [x] Integration tests: 9 market-data tests pass
- [x] Live verified: name search returns results for Tesla, Apple
- [ ] Manual: `etoro-cli market search "Tesla" --filter-by name`

Closes #28