### PR TITLE
feat: auto-fan-out batch instrument lookups

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,6 +177,7 @@ eToro API keys are environment-specific (you choose Demo or Real when generating
 - **No position SL/TP modification.** The eToro Public API does not support modifying stop loss or take profit on existing positions. The endpoint exists in eToro's internal session API (`PUT /sapi/trade-{mode}/positions/{id}`) but is not exposed in the public API. The only workaround is close + reopen.
 - **No free-text search.** The `searchText` parameter is ignored. Use `InternalSymbolFull` for server-side symbol filtering, or fetch + filter client-side for name search.
 - **Instrument IDs are not stable.** Do not hardcode instrument IDs — always use `search_instruments` to discover IDs at runtime.
+- **No batch instrument lookup.** The `/market-data/instruments` endpoint only supports one instrument ID per request. `fetchInstrumentsBatch()` transparently fans out multiple IDs into individual requests with 100ms delay between each, merging the results. This is rate-limit aware via the existing sliding-window tracker.
 
 ## Documentation files
 

--- a/README.md
+++ b/README.md
@@ -132,14 +132,14 @@ etoro-cli market search TSLA --page 1 --page-size 5
 
 #### Get instrument metadata
 
-Retrieve detailed metadata for instruments by their IDs.
+Retrieve detailed metadata for instruments by their IDs. Multiple IDs are automatically fetched individually and merged (the eToro API only supports one ID per request).
 
 ```bash
 # Single instrument
-etoro-cli market instrument 1
+etoro-cli market instrument 1137
 
-# Multiple instruments (comma-separated, look up IDs with: etoro-cli market search <name>)
-etoro-cli market instrument <id1>,<id2>,<id3>
+# Multiple instruments (auto-fans out into individual requests with rate limiting)
+etoro-cli market instrument 1137,1001,1003
 ```
 
 #### Get live rates

--- a/skills/etoro-agent/SKILL.md
+++ b/skills/etoro-agent/SKILL.md
@@ -235,8 +235,8 @@ etoro-cli market search <symbol> [--page N] [--page-size N]
 # Search instruments by name (client-side substring match)
 etoro-cli market search <name> --filter-by name [--page N] [--page-size N]
 
-# Get instrument metadata (one ID at a time — comma-separated IDs may return HTTP 500)
-etoro-cli market instrument <id>
+# Get instrument metadata (comma-separated IDs supported — auto-fans out into individual requests)
+etoro-cli market instrument <ids>              # e.g. 1137,1001,1003
 
 # Get current market prices
 etoro-cli market rates <ids>                   # comma-separated, max 100

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,7 +4,8 @@ import { EtoroClient } from "./client.js";
 import { loadConfig } from "./config.js";
 import { createPathResolver } from "./utils/path-resolver.js";
 import { EtoroApiError } from "./types/errors.js";
-import { flattenCandles } from "./tools/market-data.js";
+import { flattenCandles, fetchInstrumentsBatch } from "./tools/market-data.js";
+import { TtlCache } from "./utils/cache.js";
 import { flattenPnl, flattenPositions } from "./tools/portfolio.js";
 import { lookupInstrumentId } from "./tools/trading.js";
 import { formatTable } from "./utils/table-formatter.js";
@@ -216,10 +217,10 @@ async function main() {
             pageSize: searchPageSize,
           }));
         }
-        case "instrument":
-          return output(await client.get(paths.marketData("instruments"), {
-            instrumentIds: requireArg(rest, 0, "ids"),
-          }));
+        case "instrument": {
+          const instrumentCache = new TtlCache<unknown>();
+          return output(await fetchInstrumentsBatch(client, paths, requireArg(rest, 0, "ids"), instrumentCache));
+        }
         case "rates":
           return output(await client.get(paths.marketData("instruments/rates"), {
             instrumentIds: requireArg(rest, 0, "ids"),

--- a/src/tools/market-data.ts
+++ b/src/tools/market-data.ts
@@ -31,6 +31,58 @@ export function flattenCandles(result: unknown): unknown[] {
 const referenceCache = new TtlCache<unknown>();
 const REFERENCE_TTL = 24 * 60 * 60 * 1000; // 24 hours
 const INSTRUMENT_TTL = 60 * 60 * 1000; // 1 hour
+const FANOUT_DELAY = 100; // ms between individual instrument fetches
+
+/**
+ * Fetch instrument metadata for multiple IDs. The eToro API only supports
+ * single-ID lookups, so this fans out into individual requests with a small
+ * delay between each to stay within rate limits. Results are merged and
+ * returned in the standard { instrumentDisplayDatas: [...] } shape.
+ * Per-ID results are cached individually for 1 hour.
+ */
+export async function fetchInstrumentsBatch(
+  client: EtoroClient,
+  paths: PathResolver,
+  instrumentIds: string,
+  cache: TtlCache<unknown>,
+): Promise<Record<string, unknown>> {
+  const ids = instrumentIds.split(",").map((s) => s.trim()).filter(Boolean);
+  if (ids.length === 0) return { instrumentDisplayDatas: [] };
+
+  // Single ID — direct call
+  if (ids.length === 1) {
+    const cacheKey = `instrument:${ids[0]}`;
+    const cached = cache.get(cacheKey) as Record<string, unknown> | undefined;
+    if (cached) return cached;
+
+    const result = await client.get<Record<string, unknown>>(paths.marketData("instruments"), {
+      instrumentIds: ids[0],
+    });
+    cache.set(cacheKey, result, INSTRUMENT_TTL);
+    return result;
+  }
+
+  // Multiple IDs — fan out with delay, check cache per ID
+  const allDisplayDatas: unknown[] = [];
+  for (let i = 0; i < ids.length; i++) {
+    const id = ids[i];
+    const cacheKey = `instrument:${id}`;
+    let result = cache.get(cacheKey) as Record<string, unknown> | undefined;
+
+    if (!result) {
+      if (i > 0) await new Promise((r) => setTimeout(r, FANOUT_DELAY));
+      result = await client.get<Record<string, unknown>>(paths.marketData("instruments"), {
+        instrumentIds: id,
+      });
+      cache.set(cacheKey, result, INSTRUMENT_TTL);
+    }
+
+    const items = result.instrumentDisplayDatas as unknown[] | undefined;
+    if (items) allDisplayDatas.push(...items);
+  }
+
+  return { instrumentDisplayDatas: allDisplayDatas };
+}
 
 export async function enrichWithNames(
   client: EtoroClient,
@@ -52,26 +104,9 @@ export async function enrichWithNames(
 
   const ids = instrumentIds.split(",").map((s) => s.trim()).filter(Boolean);
   if (ids.length === 0) return rateData;
-  const sortedIds = ids.sort((a, b) => Number(a) - Number(b)).join(",");
-  const cacheKey = `instruments:${sortedIds}`;
-  let instruments: unknown = cache.get(cacheKey);
 
-  if (!instruments) {
-    instruments = await client.get(paths.marketData("instruments"), {
-      instrumentIds: sortedIds,
-    });
-    cache.set(cacheKey, instruments, INSTRUMENT_TTL);
-  }
-
-  // API returns { instrumentDisplayDatas: [...] } — unwrap if needed
-  let instrumentList: unknown[];
-  if (Array.isArray(instruments)) {
-    instrumentList = instruments;
-  } else if (typeof instruments === "object" && instruments !== null && "instrumentDisplayDatas" in instruments) {
-    instrumentList = (instruments as Record<string, unknown>).instrumentDisplayDatas as unknown[];
-  } else {
-    instrumentList = [];
-  }
+  const instruments = await fetchInstrumentsBatch(client, paths, ids.join(","), cache);
+  const instrumentList = (instruments.instrumentDisplayDatas as unknown[]) ?? [];
 
   const lookup = new Map<number, { instrumentDisplayName: string; symbolFull: string }>();
   for (const inst of instrumentList) {
@@ -161,16 +196,8 @@ export function registerMarketDataTools(
       instrumentIds: z.string().describe("Comma-separated instrument IDs (e.g. '1,2,3')"),
     },
     async ({ instrumentIds }) => {
-      const sortedIds = instrumentIds.split(",").map((s) => s.trim()).sort((a, b) => Number(a) - Number(b)).join(",");
-      const cacheKey = `instruments:${sortedIds}`;
-      const cached = referenceCache.get(cacheKey);
-      if (cached) return jsonContent(cached);
-
       try {
-        const result = await client.get(paths.marketData("instruments"), {
-          instrumentIds,
-        });
-        referenceCache.set(cacheKey, result, INSTRUMENT_TTL);
+        const result = await fetchInstrumentsBatch(client, paths, instrumentIds, referenceCache);
         return jsonContent(result);
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);

--- a/tests/unit/tools/market-data.test.ts
+++ b/tests/unit/tools/market-data.test.ts
@@ -48,16 +48,19 @@ describe("enrichWithNames", () => {
   });
 
   it("correctly merges instrument names into rate data", async () => {
-    const instrumentMetadata = [
-      { InstrumentID: 1, InstrumentDisplayName: "Apple Inc.", SymbolFull: "AAPL.US" },
-      { InstrumentID: 2, InstrumentDisplayName: "Microsoft Corp.", SymbolFull: "MSFT.US" },
-    ];
-    const rateData = [
-      { InstrumentID: 1, Ask: 150.5, Bid: 150.0 },
-      { InstrumentID: 2, Ask: 300.0, Bid: 299.5 },
-    ];
+    // fetchInstrumentsBatch calls individually for each ID — mock returns per-ID wrapped response
+    const mockFetch = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ instrumentDisplayDatas: [{ instrumentID: 1, instrumentDisplayName: "Apple Inc.", symbolFull: "AAPL.US" }] }), { status: 200, statusText: "OK", headers: { "Content-Type": "application/json" } }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ instrumentDisplayDatas: [{ instrumentID: 2, instrumentDisplayName: "Microsoft Corp.", symbolFull: "MSFT.US" }] }), { status: 200, statusText: "OK", headers: { "Content-Type": "application/json" } }));
+    const client = new EtoroClient(
+      { apiKey: "test", userKey: "test", environment: "demo" },
+      { rateLimiter: { acquire: vi.fn() } as unknown as import("../../../src/utils/rate-limiter.js").RateLimiter, fetchFn: mockFetch as typeof fetch },
+    );
 
-    const client = makeMockClient(instrumentMetadata);
+    const rateData = [
+      { instrumentID: 1, Ask: 150.5, Bid: 150.0 },
+      { instrumentID: 2, Ask: 300.0, Bid: 299.5 },
+    ];
     const result = await enrichWithNames(client, paths, "1,2", rateData, cache);
 
     const arr = result as Array<Record<string, unknown>>;
@@ -80,23 +83,25 @@ describe("enrichWithNames", () => {
   });
 
   it("does not crash when rate data contains unknown InstrumentIDs", async () => {
-    const instrumentMetadata = [
-      { InstrumentID: 1, InstrumentDisplayName: "Apple Inc.", SymbolFull: "AAPL.US" },
-    ];
-    const rateData = [
-      { InstrumentID: 1, Ask: 150.5, Bid: 150.0 },
-      { InstrumentID: 999, Ask: 50.0, Bid: 49.5 },
-    ];
+    const mockFetch = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ instrumentDisplayDatas: [{ instrumentID: 1, instrumentDisplayName: "Apple Inc.", symbolFull: "AAPL.US" }] }), { status: 200, statusText: "OK", headers: { "Content-Type": "application/json" } }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ instrumentDisplayDatas: [] }), { status: 200, statusText: "OK", headers: { "Content-Type": "application/json" } }));
+    const client = new EtoroClient(
+      { apiKey: "test", userKey: "test", environment: "demo" },
+      { rateLimiter: { acquire: vi.fn() } as unknown as import("../../../src/utils/rate-limiter.js").RateLimiter, fetchFn: mockFetch as typeof fetch },
+    );
 
-    const client = makeMockClient(instrumentMetadata);
+    const rateData = [
+      { instrumentID: 1, Ask: 150.5, Bid: 150.0 },
+      { instrumentID: 999, Ask: 50.0, Bid: 49.5 },
+    ];
     const result = await enrichWithNames(client, paths, "1,999", rateData, cache);
 
     const arr = result as Array<Record<string, unknown>>;
     expect(arr[0].instrumentDisplayName).toBe("Apple Inc.");
-    expect(arr[0].symbolFull).toBe("AAPL.US");
     // Unknown ID should not have name fields
     expect(arr[1].instrumentDisplayName).toBeUndefined();
-    expect(arr[1].InstrumentID).toBe(999);
+    expect(arr[1].instrumentID).toBe(999);
   });
 
   it("returns empty array for empty rate data", async () => {
@@ -142,31 +147,28 @@ describe("enrichWithNames", () => {
     expect(result[0].symbolFull).toBe("AAPL");
   });
 
-  it("sorts instrument IDs for consistent cache keys", async () => {
-    const instrumentMetadata = [
-      { InstrumentID: 1, InstrumentDisplayName: "Apple", SymbolFull: "AAPL" },
-      { InstrumentID: 2, InstrumentDisplayName: "Microsoft", SymbolFull: "MSFT" },
-    ];
-    const rateData = [{ InstrumentID: 1, Ask: 100 }];
+  it("caches per individual instrument ID", async () => {
+    const mockFetch = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ instrumentDisplayDatas: [{ instrumentID: 2, instrumentDisplayName: "Microsoft", symbolFull: "MSFT" }] }), { status: 200, statusText: "OK", headers: { "Content-Type": "application/json" } }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ instrumentDisplayDatas: [{ instrumentID: 1, instrumentDisplayName: "Apple", symbolFull: "AAPL" }] }), { status: 200, statusText: "OK", headers: { "Content-Type": "application/json" } }));
+    const client = new EtoroClient(
+      { apiKey: "test", userKey: "test", environment: "demo" },
+      { rateLimiter: { acquire: vi.fn() } as unknown as import("../../../src/utils/rate-limiter.js").RateLimiter, fetchFn: mockFetch as typeof fetch },
+    );
 
-    const client = makeMockClient(instrumentMetadata);
-
-    // First call with "2,1"
+    const rateData = [{ instrumentID: 1, Ask: 100 }];
     await enrichWithNames(client, paths, "2,1", rateData, cache);
 
-    // Cache should have the sorted key
-    expect(cache.has("instruments:1,2")).toBe(true);
-    expect(cache.has("instruments:2,1")).toBe(false);
+    // Individual IDs should be cached
+    expect(cache.has("instrument:1")).toBe(true);
+    expect(cache.has("instrument:2")).toBe(true);
   });
 
   it("uses cached instrument data on subsequent calls", async () => {
-    const instrumentMetadata = [
-      { InstrumentID: 1, InstrumentDisplayName: "Apple", SymbolFull: "AAPL" },
-    ];
-    const rateData = [{ InstrumentID: 1, Ask: 100 }];
+    const rateData = [{ instrumentID: 1, Ask: 100 }];
 
     const mockFetch = vi.fn().mockResolvedValue(
-      new Response(JSON.stringify(instrumentMetadata), {
+      new Response(JSON.stringify({ instrumentDisplayDatas: [{ instrumentID: 1, instrumentDisplayName: "Apple", symbolFull: "AAPL" }] }), {
         status: 200,
         statusText: "OK",
         headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
## Summary

The eToro API `/market-data/instruments` only supports one instrument ID per request. Comma-separated IDs return HTTP 500. This has persisted since v1.0.5.

### Fix
Added `fetchInstrumentsBatch()` that transparently fans out multiple IDs into individual requests:
- 100ms delay between each request to stay within rate limits
- Per-ID caching (1h TTL) — subsequent lookups for the same ID hit cache
- Used by `get_instruments` MCP tool, CLI `market instrument`, and `enrichWithNames()`
- Verified live: `1137,1001,1003` now returns all 3 instruments (NVIDIA, Apple, Meta)

### Documentation updated
- **CLAUDE.md** — added "No batch instrument lookup" to Known API limitations
- **SKILL.md** — updated CLI reference to show comma-separated IDs are supported
- **README.md** — updated instrument metadata section explaining auto-fan-out

## Test plan

- [x] `npm run build` passes
- [x] Unit tests: 181 pass
- [x] Live verified: `fetchInstrumentsBatch("1137,1001,1003")` returns 3 results
- [ ] Manual: `etoro-cli market instrument 1137,1001,1003`

Closes #32