### PR TITLE
feat: add get_market_status tool for instrument tradability

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ src/
   config.ts             # Loads config from env vars + CLI args (CLI wins), validates with Zod
   tools/
     identity.ts         # get_identity
-    market-data.ts      # search_instruments, get_instruments, get_rates, get_candles, get_reference_data
+    market-data.ts      # search_instruments, get_instruments, get_rates, get_candles, get_reference_data, get_market_status
                         #   + enrichWithNames() — cross-references instrument metadata into responses
                         #   + flattenCandles() — unwraps nested candle response, defaults null volume to 0
     trading.ts          # open_order, close_position, manage_order

--- a/README.md
+++ b/README.md
@@ -181,6 +181,16 @@ etoro-cli market ref exchanges
 etoro-cli market ref stocks-industries
 ```
 
+#### Check market status
+
+Check if instruments are currently tradeable and whether their exchanges are open.
+
+```bash
+etoro-cli market status AAPL,BTC,TSLA
+```
+
+Returns `isCurrentlyTradable`, `isExchangeOpen`, `isBuyEnabled`, exchange name, and asset class for each symbol. Use this before placing orders to verify the market is open.
+
 ### Portfolio
 
 #### View positions
@@ -605,6 +615,7 @@ Once connected, you can ask your AI assistant things like:
 | `get_rates` | Get current prices or closing prices | `instrumentIds`, `type` (current/closing_price), `includeNames` (opt-in) |
 | `get_candles` | Get OHLC candle data | `instrumentId`, `interval`, `count`, `direction` |
 | `get_reference_data` | Get instrument types, exchanges, or industries | `type`, `ids` (optional filter) |
+| `get_market_status` | Check if instruments are currently tradeable | `symbols` (comma-separated, e.g. "AAPL,BTC") |
 | `open_order` | Open a market order | `order_type` (by_amount/by_units), `InstrumentID`, `IsBuy`, `Leverage`, `Amount`/`AmountInUnits` |
 | `close_position` | Close an open position | `positionId`, `UnitsToDeduct` (optional partial close) |
 | `manage_order` | Cancel or place limit orders | `action` (cancel_open_order/cancel_close_order/place_limit_order/cancel_limit_order), `orderId`, order params |

--- a/skills/etoro-agent/SKILL.md
+++ b/skills/etoro-agent/SKILL.md
@@ -254,6 +254,9 @@ etoro-cli market candles <instrumentId> \
 etoro-cli market ref instrument-types
 etoro-cli market ref exchanges
 etoro-cli market ref stocks-industries
+
+# Check if instruments are currently tradeable
+etoro-cli market status AAPL,BTC,TSLA
 ```
 
 ### Portfolio
@@ -377,6 +380,7 @@ etoro-cli discovery recommendations [--count N] # personalized picks (default: 1
 | `get_rates` | Live prices or closing prices | `instrumentIds`, `type` (current/closing_price), `includeNames` (opt-in) |
 | `get_candles` | OHLC history | `instrumentId`, `interval`, `count`, `direction` |
 | `get_reference_data` | Cached reference data | `type` (instrument_types/exchanges/stocks_industries) |
+| `get_market_status` | Check if instruments are tradeable | `symbols` (comma-separated, e.g. "AAPL,BTC") |
 | `get_portfolio` | Positions, P&L, order status | `view` (positions/pnl/order), `orderId` |
 | `get_trade_history` | Closed trades | `minDate` (YYYY-MM-DD), `page`, `pageSize` |
 | `search_people` | Find traders | `action` (search/lookup), `period`, `isPopularInvestor` |

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -107,6 +107,7 @@ Commands:
     --count <n>                        Number of candles, max 1000 (default: 100)
     --direction <dir>                  asc or desc (default: desc)
   market ref <type>                  Reference data: instrument-types|exchanges|stocks-industries
+  market status <symbols>            Check if instruments are tradeable (comma-separated symbols)
 
   portfolio positions                Current portfolio positions
   portfolio pnl                      Portfolio P&L summary
@@ -241,8 +242,37 @@ async function main() {
           return output(await client.get(paths.marketData(
             requireArg(rest, 0, "type").replace("_", "-"),
           )));
+        case "status": {
+          const symbols = requireArg(rest, 0, "symbols").split(",").map((s: string) => s.trim().toUpperCase()).filter(Boolean);
+          const statuses: Array<Record<string, unknown>> = [];
+          for (const symbol of symbols) {
+            const result = await client.get<Record<string, unknown>>(paths.marketData("search"), {
+              InternalSymbolFull: symbol,
+              pageSize: 1,
+              pageNumber: 1,
+            });
+            const items = result.items as Array<Record<string, unknown>> | undefined;
+            if (!items || items.length === 0) {
+              statuses.push({ symbol, found: false });
+              continue;
+            }
+            const item = items[0];
+            statuses.push({
+              symbol,
+              found: true,
+              instrumentId: item.internalInstrumentId ?? item.instrumentId,
+              displayName: item.internalInstrumentDisplayName ?? item.instrumentDisplayName,
+              isCurrentlyTradable: item.isCurrentlyTradable ?? null,
+              isExchangeOpen: item.isExchangeOpen ?? null,
+              isBuyEnabled: item.isBuyEnabled ?? null,
+              exchangeName: item.internalExchangeName ?? null,
+              assetClass: item.internalAssetClassName ?? null,
+            });
+          }
+          return output(statuses);
+        }
         default:
-          error(`Unknown market subcommand: ${sub}. Try: search, instrument, rates, candles, ref`);
+          error(`Unknown market subcommand: ${sub}. Try: search, instrument, rates, candles, ref, status`);
       }
       break;
 

--- a/src/tools/market-data.ts
+++ b/src/tools/market-data.ts
@@ -306,4 +306,51 @@ export function registerMarketDataTools(
       }
     },
   );
+
+  server.tool(
+    "get_market_status",
+    "Check if instruments are currently tradeable and whether their markets are open. Returns tradability status for one or more instruments.",
+    {
+      symbols: z.string().describe("Comma-separated ticker symbols (e.g. 'AAPL,BTC,TSLA')"),
+    },
+    async ({ symbols }) => {
+      try {
+        const symbolList = symbols.split(",").map((s) => s.trim().toUpperCase()).filter(Boolean);
+        const statuses: Array<Record<string, unknown>> = [];
+
+        for (const symbol of symbolList) {
+          const result = await client.get<Record<string, unknown>>(paths.marketData("search"), {
+            InternalSymbolFull: symbol,
+            pageSize: 1,
+            pageNumber: 1,
+          });
+
+          const items = result.items as Array<Record<string, unknown>> | undefined;
+          if (!items || items.length === 0) {
+            statuses.push({ symbol, found: false });
+            continue;
+          }
+
+          const item = items[0];
+          statuses.push({
+            symbol,
+            found: true,
+            instrumentId: item.internalInstrumentId ?? item.instrumentId,
+            displayName: item.internalInstrumentDisplayName ?? item.instrumentDisplayName,
+            isCurrentlyTradable: item.isCurrentlyTradable ?? null,
+            isExchangeOpen: item.isExchangeOpen ?? null,
+            isBuyEnabled: item.isBuyEnabled ?? null,
+            isActiveInPlatform: item.isActiveInPlatform ?? null,
+            exchangeName: item.internalExchangeName ?? null,
+            assetClass: item.internalAssetClassName ?? null,
+          });
+        }
+
+        return jsonContent(statuses);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return errorContent(`Failed to get market status: ${message}`);
+      }
+    },
+  );
 }

--- a/tests/unit/tools/market-data.test.ts
+++ b/tests/unit/tools/market-data.test.ts
@@ -389,3 +389,69 @@ describe("flattenCandles", () => {
     expect(candle).not.toHaveProperty("volume");
   });
 });
+
+describe("get_market_status (via mock client)", () => {
+  it("fetches tradability status for a single symbol", async () => {
+    const paths = createPathResolver("demo");
+    const searchResponse = {
+      items: [{
+        internalInstrumentId: 1001,
+        internalInstrumentDisplayName: "Apple",
+        internalSymbolFull: "AAPL",
+        isCurrentlyTradable: true,
+        isExchangeOpen: true,
+        isBuyEnabled: true,
+        isActiveInPlatform: true,
+        internalExchangeName: "Nasdaq",
+        internalAssetClassName: "Stocks",
+      }],
+      totalItems: 1,
+    };
+    const mockFetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(searchResponse), { status: 200, statusText: "OK", headers: { "Content-Type": "application/json" } }),
+    );
+    const client = new EtoroClient(
+      { apiKey: "test", userKey: "test", environment: "demo" },
+      { rateLimiter: { acquire: vi.fn() } as unknown as import("../../../src/utils/rate-limiter.js").RateLimiter, fetchFn: mockFetch as typeof fetch },
+    );
+
+    const result = await client.get<Record<string, unknown>>(paths.marketData("search"), {
+      InternalSymbolFull: "AAPL",
+      pageSize: 1,
+      pageNumber: 1,
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [url] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const parsed = new URL(url);
+    expect(parsed.searchParams.get("InternalSymbolFull")).toBe("AAPL");
+    expect(parsed.searchParams.get("pageSize")).toBe("1");
+
+    const items = result.items as Array<Record<string, unknown>>;
+    expect(items[0].isCurrentlyTradable).toBe(true);
+    expect(items[0].isExchangeOpen).toBe(true);
+    expect(items[0].isBuyEnabled).toBe(true);
+    expect(items[0].internalExchangeName).toBe("Nasdaq");
+    expect(items[0].internalAssetClassName).toBe("Stocks");
+  });
+
+  it("returns found:false for unknown symbols", async () => {
+    const paths = createPathResolver("demo");
+    const mockFetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ items: [], totalItems: 0 }), { status: 200, statusText: "OK", headers: { "Content-Type": "application/json" } }),
+    );
+    const client = new EtoroClient(
+      { apiKey: "test", userKey: "test", environment: "demo" },
+      { rateLimiter: { acquire: vi.fn() } as unknown as import("../../../src/utils/rate-limiter.js").RateLimiter, fetchFn: mockFetch as typeof fetch },
+    );
+
+    const result = await client.get<Record<string, unknown>>(paths.marketData("search"), {
+      InternalSymbolFull: "XYZNOTREAL",
+      pageSize: 1,
+      pageNumber: 1,
+    });
+
+    const items = result.items as Array<unknown>;
+    expect(items).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

New MCP tool and CLI command to check if instruments are currently tradeable.

### MCP tool
```
get_market_status(symbols: "AAPL,BTC,TSLA")
```

### CLI
```bash
etoro-cli market status AAPL,BTC,TSLA
```

### Returns per symbol
- `instrumentId`, `displayName`, `exchangeName`, `assetClass`
- `isCurrentlyTradable` — can you trade it right now?
- `isExchangeOpen` — is the exchange currently open?
- `isBuyEnabled` — are buy orders accepted?

### Why
Autonomous trading agents need to know if a market is open before placing orders. Without this, orders on closed markets either fail silently or queue until open.

### End-to-end checklist
- [x] MCP tool (`src/tools/market-data.ts`)
- [x] CLI (`src/cli.ts` — `market status` command + help text)
- [x] Unit tests (2 new tests)
- [x] SKILL.md (tool table + CLI reference)
- [x] README.md (CLI docs + MCP tools table)
- [x] CLAUDE.md (architecture — added get_market_status to file listing)
- [x] Build passes
- [x] 190 tests pass

Closes #36