### PR TITLE
docs: document stop entry orders via limit order command

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,17 +262,22 @@ etoro-cli trade open-units --instrument <instrument_id> --buy --leverage 1 --uni
 etoro-cli trade close 12345678
 ```
 
-#### Place a limit order
+#### Place a limit or stop entry order
 
-A limit order executes when the instrument reaches your specified price.
+A limit order executes when the instrument reaches your specified price. The same command works for both limit entries (buy the dip) and stop entries (buy the breakout) — the API accepts any rate:
 
 ```bash
-# Buy Apple when it hits $150
-etoro-cli trade limit --instrument 1 --buy --leverage 1 --amount 100 --rate 150.00
-
-# With stop loss and take profit
-etoro-cli trade limit --instrument 1 --buy --leverage 1 --amount 100 --rate 150.00 \
+# Limit buy — buy when price DROPS to $150
+etoro-cli trade limit --instrument 1001 --buy --leverage 1 --amount 100 --rate 150.00 \
   --stop-loss 140.00 --take-profit 180.00
+
+# Stop entry buy (breakout) — buy when price RISES to $260
+etoro-cli trade limit --instrument 1111 --buy --leverage 1 --amount 500 --rate 260.00 \
+  --stop-loss 250.00 --take-profit 280.00
+
+# Stop entry sell (breakdown) — short when price DROPS to $4300
+etoro-cli trade limit --instrument 18 --sell --leverage 1 --amount 1000 --rate 4300.00 \
+  --stop-loss 4400.00 --take-profit 4100.00
 ```
 
 #### Cancel an order

--- a/skills/etoro-agent/SKILL.md
+++ b/skills/etoro-agent/SKILL.md
@@ -297,10 +297,23 @@ etoro-cli trade open-units \
 etoro-cli trade close <positionId>
 
 # Place a limit order (executes when price reaches --rate)
+# Works as BOTH limit entry AND stop entry:
+#   - Rate BELOW market + buy = limit buy (dip buy)
+#   - Rate ABOVE market + buy = stop buy (breakout entry)
+#   - Rate ABOVE market + sell = limit sell (take profit)
+#   - Rate BELOW market + sell = stop sell (breakdown entry)
 etoro-cli trade limit \
   --instrument <id> --buy | --sell \
   --leverage <n> --amount <n> --rate <price> \
   [--stop-loss <rate>] [--take-profit <rate>]
+
+# Example: breakout buy — enter TSLA if it breaks above 260
+etoro-cli trade limit --instrument 1111 --buy --leverage 1 --amount 500 --rate 260 \
+  --stop-loss 250 --take-profit 280
+
+# Example: breakdown sell — short GOLD if it drops below 4300
+etoro-cli trade limit --instrument 18 --sell --leverage 1 --amount 1000 --rate 4300 \
+  --stop-loss 4400 --take-profit 4100
 
 # Cancel a pending order (auto-detects limit vs market order)
 etoro-cli trade cancel <orderId>


### PR DESCRIPTION
## Summary

Stop entry (breakout/breakdown) orders are already supported — the eToro limit-orders endpoint accepts any rate, above or below market. No code changes needed, just documentation.

**Verified live:**
- Buy at 72000 when BTC was at 71110 (stop buy): accepted
- Sell at 70000 when BTC was at 71110 (stop sell): accepted

### Changes
- **SKILL.md**: documented that `trade limit` works for both limit and stop entries, with breakout buy and breakdown sell examples
- **README.md**: renamed section to "Place a limit or stop entry order", added stop entry examples

### End-to-end checklist
- [x] No code changes needed (existing `place_limit_order` already works)
- [x] SKILL.md updated
- [x] README.md updated
- [x] Build passes, 201 tests pass

Closes #43